### PR TITLE
Adapt to changed parent lib SO version libyui.so.13

### DIFF
--- a/VERSION.cmake
+++ b/VERSION.cmake
@@ -1,6 +1,6 @@
 SET( VERSION_MAJOR "0")
 SET( VERSION_MINOR "2" )
-SET( VERSION_PATCH "0" )
+SET( VERSION_PATCH "1" )
 SET( VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}${GIT_SHA1_VERSION}" )
 
 ##### This is need for the libyui core ONLY.
@@ -8,7 +8,7 @@ SET( VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}${GIT_SHA1_VERSI
 # Currently you must also change so_version in libyui.spec
 # *and also in **all** other* libyui-*.spec files in the other repositories.
 # Yes, such a design is suboptimal.
-SET( SONAME_MAJOR "12" )
+SET( SONAME_MAJOR "0" )
 SET( SONAME_MINOR "0" )
 SET( SONAME_PATCH "0" )
 SET( SONAME "${SONAME_MAJOR}.${SONAME_MINOR}.${SONAME_PATCH}" )

--- a/package/libyui-ncurses-rest-api.changes
+++ b/package/libyui-ncurses-rest-api.changes
@@ -1,10 +1,18 @@
 -------------------------------------------------------------------
+Tue Aug 11 14:31:02 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Use new parent lib SO version libyui.so.13 (bsc#1175115)
+- 0.2.1
+
+-------------------------------------------------------------------
 Mon Jun  8 14:37:04 UTC 2020 - Rodion Iafarov <riafarov@suse.com>
 
 - Trigger update on YCombobox, YSelectionBox, YInputField,
   YMultiSelectionBox (bsc#1139747)
 - Add support for YDateField and YTimeField
 - Add support for YCheckBoxFrame
+- 0.2.0
+
 -------------------------------------------------------------------
 Thu Jun  4 13:17:49 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
 

--- a/package/libyui-ncurses-rest-api.spec
+++ b/package/libyui-ncurses-rest-api.spec
@@ -16,12 +16,12 @@
 #
 
 
-%define so_version 12
+%define so_version 13
 %define bin_name %{name}%{so_version}
 %define libyui_devel_version libyui-devel >= 3.8.0
 
 Name:           libyui-ncurses-rest-api
-Version:        0.2.0
+Version:        0.2.1
 Release:        0
 Summary:        Libyui - The REST API plugin for the Ncurses frontend
 License:        LGPL-2.1-only OR LGPL-3.0-only


### PR DESCRIPTION
## Trello

https://trello.com/c/4GtDpmMo/1956-5-menu-bar-widget

## Overview

There is now a new MenuBar widget in libyui, so the SO version needed to be bumped.
This PR adapts this repo to that new SO version.

## Master PR

https://github.com/libyui/libyui/pull/169